### PR TITLE
fix: Update segregation codes filter [PAGOPA-1260]

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: pagopa-gpd-payments
 description: Microservice that exposes API for payment receipts retrieving and other operations
 type: application
-version: 0.27.0
-appVersion: 0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat
+version: 0.28.0
+appVersion: 0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat
 dependencies:
   - name: microservice-chart
     version: 1.21.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: pagopa-gpd-payments
 description: Microservice that exposes API for payment receipts retrieving and other operations
 type: application
-version: 0.26.0
-appVersion: 0.9.4
+version: 0.27.0
+appVersion: 0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat
 dependencies:
   - name: microservice-chart
     version: 1.21.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4"
+    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
+    tag: "0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4"
+    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
+    tag: "0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4"
+    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
+    tag: "0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "PagoPA API Payments",
     "description": "Payments",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
+    "version": "0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "PagoPA API Payments",
     "description": "Payments",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.9.4"
+    "version": "0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>payments</artifactId>
-    <version>0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat</version>
+    <version>0.9.4-2-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat</version>
     <name>Payments</name>
     <description>Payments</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>payments</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.4-1-PAGOPA-1260-bug-fix-gpd-payments-segregation-code-uat</version>
     <name>Payments</name>
     <description>Payments</description>
 

--- a/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
@@ -163,7 +163,7 @@ public class PaymentsService {
         if(segCodes != null && !segCodes.isEmpty()) {
             ArrayList<String> segCodesFilters = new ArrayList<>();
             for(String segCode: segCodes) {
-                segCodesFilters.add(this.getStartsWithFilter("RowKey", "3" + segCode) + " and " + filter);
+                segCodesFilters.add(this.getStartsWithFilter("RowKey", segCode) + " and " + filter);
             }
             filter = String.join(" or ", segCodesFilters);
         }

--- a/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
@@ -63,8 +63,8 @@ public class PaymentsService {
             @NotBlank String organizationFiscalCode, @NotBlank String iuv, ArrayList<String> validSegregationCodes) {
 
         try {
-            if(validSegregationCodes != null && iuv.length() > 3) {
-                String iuvSegregationCode = iuv.substring(1,3);
+            if(validSegregationCodes != null && !validSegregationCodes.isEmpty() && iuv.length() > 1) {
+                String iuvSegregationCode = iuv.substring(0,2);
                 if(!isBrokerAuthorized(iuvSegregationCode, validSegregationCodes))
                     throw new AppException(AppError.FORBIDDEN_SEGREGATION_CODE, iuvSegregationCode, organizationFiscalCode, iuv);
             }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Aux-digit adding in the segregation code filter has been removed;

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Notice number format is define as follows:

- `3<segregation code(2n)><IUV base(13n)><IUV check digit(2n)>`

GPD service works on IUVs directly, so we remove the Aux-Digit

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.