### PR TITLE
fix: validation on office_name, company_name and description [PAGOPA-1680] 

### DIFF
--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -96,6 +96,9 @@ public class PartnerService {
   public static final String PAYMENT_DATE_PROPERTY = "paymentDate";
   
   public static final String IBAN_APPOGGIO_KEY = "IBANAPPOGGIO";
+  public static final int PAYMENT_OPTION_DESCRIPTION_MAX = 140;
+  public static final int OFFICE_NAME_MAX = 140;
+  public static final int COMPANY_NAME_MAX = 140;
 
   @Value(value = "${xsd.generic-service}")
   private Resource xsdGenericService;
@@ -279,8 +282,15 @@ public class PartnerService {
 
   private PaDemandPaymentNoticeResponse createPaDemandPaymentNoticeResponse(
       PaymentPositionModel gpsResponse) throws DatatypeConfigurationException {
+    String officeName = Optional.ofNullable(gpsResponse.getOfficeName())
+                                .map(office -> office.length() > OFFICE_NAME_MAX ? office.substring(OFFICE_NAME_MAX) : null)
+                                .orElse(null);
+    String description = Optional.ofNullable(gpsResponse.getPaymentOption().get(0).getDescription())
+                                 .orElse("NA").substring(PAYMENT_OPTION_DESCRIPTION_MAX);
+    String companyName = Optional.ofNullable(gpsResponse.getCompanyName()).orElse("NA").substring(COMPANY_NAME_MAX);
+
     var result = factory.createPaDemandPaymentNoticeResponse();
-    result.setCompanyName(gpsResponse.getCompanyName());
+    result.setCompanyName(companyName);
     result.setOutcome(StOutcome.OK);
     result.setFiscalCodePA(gpsResponse.getFiscalCode());
 
@@ -289,8 +299,8 @@ public class PartnerService {
     ctQrCode.setNoticeNumber(gpsResponse.getPaymentOption().get(0).getIuv());
     result.setQrCode(ctQrCode);
 
-    result.setOfficeName(gpsResponse.getOfficeName());
-    result.setPaymentDescription(Optional.ofNullable(gpsResponse.getPaymentOption().get(0).getDescription()).orElse("NA"));
+    result.setOfficeName(officeName);
+    result.setPaymentDescription(description);
     CtPaymentOptionsDescriptionListPA ctPaymentOptionsDescriptionListPA =
         factory.createCtPaymentOptionsDescriptionListPA();
 
@@ -378,10 +388,17 @@ public class PartnerService {
       responseData.setRetentionDate(retentionDateXMLGregorian);
     }
 
+    String description = Optional.ofNullable(source.getDescription()).orElse("NA").substring(PAYMENT_OPTION_DESCRIPTION_MAX);
+    String companyName = Optional.ofNullable(source.getCompanyName()).orElse("NA").substring(COMPANY_NAME_MAX);
+    String officeName = Optional.ofNullable(source.getOfficeName())
+                                .map(office -> office.length() > OFFICE_NAME_MAX ? office.substring(OFFICE_NAME_MAX) : null)
+                                .orElse(null);
+
     responseData.setLastPayment(false); // de-scoping
-    responseData.setDescription(Optional.ofNullable(source.getDescription()).orElse("NA"));
-    responseData.setCompanyName(Optional.ofNullable(source.getCompanyName()).orElse("NA"));
-    responseData.setOfficeName(source.getOfficeName());
+    responseData.setDescription(description);
+    responseData.setCompanyName(companyName);
+    responseData.setOfficeName(officeName);
+
     CtSubject debtor = this.getDebtor(source);
     responseData.setDebtor(debtor);
 
@@ -437,10 +454,16 @@ public class PartnerService {
       responseData.setRetentionDate(retentionDateXMLGregorian);
     }
 
+    String description = Optional.ofNullable(source.getDescription()).orElse("NA").substring(PAYMENT_OPTION_DESCRIPTION_MAX);
+    String companyName = Optional.ofNullable(source.getCompanyName()).orElse("NA").substring(COMPANY_NAME_MAX);
+    String officeName = Optional.ofNullable(source.getOfficeName())
+                                .map(office -> office.length() > OFFICE_NAME_MAX ? office.substring(OFFICE_NAME_MAX) : null)
+                                .orElse(null);
+
     responseData.setLastPayment(false); // de-scoping
-    responseData.setDescription(Optional.ofNullable(source.getDescription()).orElse("NA"));
-    responseData.setCompanyName(Optional.ofNullable(source.getCompanyName()).orElse("NA"));
-    responseData.setOfficeName(source.getOfficeName());
+    responseData.setDescription(description);
+    responseData.setCompanyName(companyName);
+    responseData.setOfficeName(officeName);
 
     List<PaymentOptionMetadataModel> paymentOptionMetadataModels = source.getPaymentOptionMetadata();
     if(paymentOptionMetadataModels != null && !paymentOptionMetadataModels.isEmpty()) {
@@ -509,10 +532,15 @@ public class PartnerService {
 
     result.setPaymentList(paymentList);
     // general info
-    result.setPaymentDescription(Optional.ofNullable(source.getDescription()).orElse("NA"));
+    String description = Optional.ofNullable(source.getDescription()).orElse("NA").substring(PAYMENT_OPTION_DESCRIPTION_MAX);
+    String companyName = Optional.ofNullable(source.getCompanyName()).orElse("NA").substring(COMPANY_NAME_MAX);
+    String officeName = Optional.ofNullable(source.getOfficeName())
+                                .map(office -> office.length() > OFFICE_NAME_MAX ? office.substring(OFFICE_NAME_MAX) : null)
+                                .orElse(null);
+    result.setPaymentDescription(description);
     result.setFiscalCodePA(source.getOrganizationFiscalCode());
-    result.setCompanyName(Optional.ofNullable(source.getCompanyName()).orElse("NA"));
-    result.setOfficeName(source.getOfficeName());
+    result.setCompanyName(companyName);
+    result.setOfficeName(officeName);
     return result;
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Add validation on office_name, company_name and description in: `paGetPaymentResponse`,  `paGetPaymentResponseV2`, `paDemandPaymentNoticeResponse`, `PaVerifyPaymentNoticeResponse` generation
- if an invalid length was provided the fields are updated (substring)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- SANP compliance

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.