### PR TITLE
feat: [PAGOPA-3233] Add feature-flag to suppress fault-code errors from specific stations

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -87,8 +87,9 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-d-weu-core-evh-ns04"
-    # List of stations for which "Not Found" errors are ignored: response override with "OK".
-    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
+    # List of stations for which SUPPRESSED_ERRORS_VALUES are ignored: response override with "OK".
+    SUPPRESSED_ERRORS_STATIONS: "15376371009_11"
+    SUPPRESSED_ERRORS_VALUES: "PAA_PAGAMENTO_SCONOSCIUTO,PAA_RECEIPT_DUPLICATA"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-d-connection-string'

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -87,6 +87,8 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-d-weu-core-evh-ns04"
+    # List of stations for which "Not Found" errors are ignored: response override with "OK".
+    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-d-connection-string'

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -87,6 +87,8 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-p-weu-core-evh-ns04"
+    # List of stations for which "Not Found" errors are ignored: response override with "OK".
+    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-p-connection-string'

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -87,8 +87,9 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-p-weu-core-evh-ns04"
-    # List of stations for which "Not Found" errors are ignored: response override with "OK".
-    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
+    # List of stations for which "Not Found" or "Duplicated Receipt" errors are ignored: response override with "OK".
+    SUPPRESSED_ERRORS_STATIONS: "15376371009_11"
+    SUPPRESSED_ERRORS_VALUES: "PAA_PAGAMENTO_SCONOSCIUTO,PAA_RECEIPT_DUPLICATA"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-p-connection-string'

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -87,8 +87,9 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-u-weu-core-evh-ns04"
-    # List of stations for which "Not Found" errors are ignored: response override with "OK".
-    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
+    # List of stations for which "Not Found" or "Duplicated Receipt" errors are ignored: response override with "OK".
+    SUPPRESSED_ERRORS_STATIONS: "15376371009_11"
+    SUPPRESSED_ERRORS_VALUES: "PAA_PAGAMENTO_SCONOSCIUTO,PAA_RECEIPT_DUPLICATA"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-u-connection-string'

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -87,6 +87,8 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RETRY_TRIGGER: "0 0 0,6,12,18 * * *"
     SERVICE_NAME: "pagopa-gpd-payments"
     CONFIG_CACHE_EVENTHUB_NAME: "pagopa-u-weu-core-evh-ns04"
+    # List of stations for which "Not Found" errors are ignored: response override with "OK".
+    SUPPRESSED_NOT_FOUND_ERRORS_STATIONS: "15376371009_11"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-u-connection-string'

--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -230,7 +230,7 @@ public class PartnerService {
       if (!stationsWithSuppressedErrors.contains(request.getIdStation()) || !suppressedErrorsValues.contains(e.getError().getFaultCode())) {
         throw e;
       } else {
-        log.warn("[paSendRTV2] Suppressed error '{}' from station '{}' for [noticeNumber={}].",
+        log.debug("[paSendRTV2] Suppressed error '{}' from station '{}' for [noticeNumber={}].",
                 e.getError().getFaultCode(),
                 request.getIdStation(),
                 noticeNumber);

--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -90,8 +90,12 @@ public class PartnerService {
   @Value(value = "${azure.queue.send.invisibilityTime}")
   private Long queueSendInvisibilityTime;
 
-  @Value(value = "${stations.SuppressedNotFoundErrors}")
-  private List<String> stationsWithSuppressedNotFoundErrors;
+  @Value(value = "${suppressedErrors.stations}")
+  private List<String> stationsWithSuppressedErrors;
+
+  // PaaErrorEnum.java fault codes subset
+  @Value(value = "${suppressedErrors.values}")
+  private List<String> suppressedErrorsValues;
 
   @Autowired private ObjectFactory factory;
 
@@ -220,8 +224,8 @@ public class PartnerService {
           throw new PartnerValidationException(PaaErrorEnum.PAA_SEMANTICA);
       }
     } catch (PartnerValidationException e) {
-      // Re-throw the exception unless it's a PAA_PAGAMENTO_SCONOSCIUTO error from station included in the suppression list.
-      if (!e.getError().equals(PaaErrorEnum.PAA_PAGAMENTO_SCONOSCIUTO) || !stationsWithSuppressedNotFoundErrors.contains(request.getIdStation())) {
+      // Re-throw the exception unless it's a suppressed fault code error from station included in the suppression list.
+      if (!suppressedErrorsValues.contains(e.getError().getFaultCode()) || !stationsWithSuppressedErrors.contains(request.getIdStation())) {
         throw e;
       }
     }

--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -90,13 +90,6 @@ public class PartnerService {
   @Value(value = "${azure.queue.send.invisibilityTime}")
   private Long queueSendInvisibilityTime;
 
-  @Value(value = "${suppressedErrors.stations}")
-  private List<String> stationsWithSuppressedErrors;
-
-  // PaaErrorEnum.java fault codes subset
-  @Value(value = "${suppressedErrors.values}")
-  private List<String> suppressedErrorsValues;
-
   @Autowired private ObjectFactory factory;
 
   @Autowired private GpdClient gpdClient;
@@ -108,6 +101,13 @@ public class PartnerService {
   @Autowired private QueueClient queueClient;
 
   @Autowired private CustomizedMapper customizedModelMapper;
+
+  @Value(value = "${suppressedErrors.stations}")
+  private List<String> stationsWithSuppressedErrors;
+
+  // PaaErrorEnum.java fault codes subset
+  @Value(value = "${suppressedErrors.values}")
+  private List<String> suppressedErrorsValues;
 
   private static final String DBERROR = "Error in organization table connection";
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,10 @@ service.apiconfig.host=${API_CONFIG_HOST}
 azure.tables.tableName=${AZURE_TABLES_TABLENAME}
 azure.tables.connection.string=${AZURE_TABLES_CONNECTION_STRING}
 
+# List of stations for which "Not Found" errors are ignored: response override with "OK".
+# This value is typically set by an environment variable (e.g., SUPPRESSED_NOT_FOUND_ERRORS_STATIONS=15376371009_11).
+# If the environment variable is not set, the list will be empty.
+stations.SuppressedNotFoundErrors=${SUPPRESSED_NOT_FOUND_ERRORS_STATIONS:}
 
 # logging level settings
 logging.level.root=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,10 +28,11 @@ service.apiconfig.host=${API_CONFIG_HOST}
 azure.tables.tableName=${AZURE_TABLES_TABLENAME}
 azure.tables.connection.string=${AZURE_TABLES_CONNECTION_STRING}
 
-# List of stations for which "Not Found" errors are ignored: response override with "OK".
-# This value is typically set by an environment variable (e.g., SUPPRESSED_NOT_FOUND_ERRORS_STATIONS=15376371009_11).
+# List of stations for which suppressedErrors.values (ie "PAA_PAGAMENTO_SCONOSCIUTO" ) errors are ignored: response override with "OK".
+# This value is typically set by an environment variable (e.g., SUPPRESSED_ERRORS_STATIONS=15376371009_11).
 # If the environment variable is not set, the list will be empty.
-stations.SuppressedNotFoundErrors=${SUPPRESSED_NOT_FOUND_ERRORS_STATIONS:}
+suppressedErrors.stations=${SUPPRESSED_ERRORS_STATIONS:}
+suppressedErrors.values=${SUPPRESSED_ERRORS_VALUES:}
 
 # logging level settings
 logging.level.root=INFO

--- a/src/test/java/it/gov/pagopa/payments/service/PartnerServiceTest.java
+++ b/src/test/java/it/gov/pagopa/payments/service/PartnerServiceTest.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+import java.util.List;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
@@ -447,7 +448,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("34");
@@ -495,7 +496,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222222");
@@ -543,7 +544,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222222");
@@ -597,7 +598,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock(iuv);
@@ -647,7 +648,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222224");
@@ -695,7 +696,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222225");
 
@@ -742,7 +743,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222226");
@@ -799,7 +800,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     var requestBody = PaDemandNoticePaymentReqMock.getMock();
@@ -846,7 +847,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     var requestBody = PaDemandNoticePaymentReqMock.getMock();
@@ -882,7 +883,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaGetPaymentV2Request requestBody = PaGetPaymentReqMock.getMockV2();
@@ -948,7 +949,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaGetPaymentV2Request requestBody = PaGetPaymentReqMock.getMockV2();
@@ -994,7 +995,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaGetPaymentV2Request requestBody = PaGetPaymentReqMock.getMockTransferTypePAGOPA();
@@ -1083,7 +1084,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaGetPaymentV2Request requestBody = PaGetPaymentReqMock.getMockV2();
@@ -1197,7 +1198,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222231");
@@ -1245,7 +1246,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222232");
@@ -1293,7 +1294,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222232");
@@ -1347,7 +1348,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2(iuv);
@@ -1397,7 +1398,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222234");
@@ -1445,7 +1446,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222235");
 
@@ -1492,7 +1493,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222236");
@@ -1540,7 +1541,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTV2Request requestBody = PaSendRTReqMock.getMockV2("11111111112222239");
@@ -1591,7 +1592,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
 
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222240");
@@ -1642,7 +1643,7 @@ class PartnerServiceTest {
                 gpsClient,
                 tableClientConfiguration(),
                 queueClientConfiguration(),
-                customizedModelMapper));
+                customizedModelMapper, List.of(), List.of()));
     // Test preconditions
     PaSendRTReq requestBody = PaSendRTReqMock.getMock("11111111112222225");
 

--- a/src/test/java/it/gov/pagopa/payments/service/SchedulerServiceTest.java
+++ b/src/test/java/it/gov/pagopa/payments/service/SchedulerServiceTest.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.time.Duration;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -108,7 +109,7 @@ class SchedulerServiceTest {
                             gpsClient,
                             tableClientConfiguration(),
                             queueClientConfiguration(),
-                            customizedModelMapper));
+                            customizedModelMapper, List.of(), List.of()));
 
     var schedService =
             spy(
@@ -174,7 +175,7 @@ class SchedulerServiceTest {
                             gpsClient,
                             tableClientConfiguration(),
                             queueClientConfiguration(),
-                            customizedModelMapper));
+                            customizedModelMapper, List.of(), List.of()));
 
     var schedService =
             spy(
@@ -240,7 +241,7 @@ class SchedulerServiceTest {
                             gpsClient,
                             tableClientConfiguration(),
                             queueClientConfiguration(),
-                            customizedModelMapper));
+                            customizedModelMapper, List.of(), List.of()));
 
     var schedService =
             spy(

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -20,6 +20,9 @@ service.apiconfig.host=http://localhost:8083/apiconfig/api/v1
 azure.tables.tableName=testTable
 azure.tables.connection.string=DefaultEndpointsProtocol=http;AccountName=localhost;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;TableEndpoint=http://localhost:8902/;
 
+# List of stations for which suppressedErrors.values (ie "PAA_PAGAMENTO_SCONOSCIUTO" ) errors are ignored: response override with "OK".
+suppressedErrors.stations=${SUPPRESSED_ERRORS_STATIONS:}
+suppressedErrors.values=${SUPPRESSED_ERRORS_VALUES:}
 
 # logging level settings
 logging.level.root=INFO


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Add feature-flag to suppress fault-code errors from specific stations, example of use:
```
SUPPRESSED_ERRORS_STATIONS: "15376371009_11"
SUPPRESSED_ERRORS_VALUES: "PAA_PAGAMENTO_SCONOSCIUTO,PAA_RECEIPT_DUPLICATA"
```

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Reduce error noise due to broadcast default stations for ACA.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested in local environment with various scenarios.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.