### PR TITLE
fix: use receipt fiscal code instead of pa id in paSendRt V1/V2

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-gpd-payments
 description: Microservice that exposes API for payment receipts retrieving and other operations
 type: application
-version: 0.157.0
-appVersion: 0.13.3
+version: 0.158.0
+appVersion: 0.13.4-PIDM-2218-update-wrong-debt-position
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.13.3"
+    tag: "0.13.4-PIDM-2218-update-wrong-debt-position"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.13.3"
+    tag: "0.13.4-PIDM-2218-update-wrong-debt-position"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-payments
-    tag: "0.13.3"
+    tag: "0.13.4-PIDM-2218-update-wrong-debt-position"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "PagoPA API Payments",
     "description": "Payments",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.13.3"
+    "version": "0.13.4-PIDM-2218-update-wrong-debt-position"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>payments</artifactId>
-    <version>0.13.3</version>
+    <version>0.13.4-PIDM-2218-update-wrong-debt-position</version>
     <name>Payments</name>
     <description>Payments</description>
 

--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -838,7 +838,7 @@ public class PartnerService {
             .orElse("");
     ReceiptEntity receiptEntity =
         this.getReceiptEntity(
-            request.getIdPA(),
+            request.getReceipt().getFiscalCode(),
             request.getReceipt().getCreditorReferenceId(),
             debtorIdentifier,
             request.getReceipt().getPaymentDateTime().toString());
@@ -877,7 +877,7 @@ public class PartnerService {
 
     return this.getReceiptExceptionHandling(
         request.getReceipt().getNoticeNumber(),
-        request.getIdPA(),
+        request.getReceipt().getFiscalCode(),
         request.getReceipt().getCreditorReferenceId(),
         isStandIn,
         body,
@@ -896,7 +896,7 @@ public class PartnerService {
             .orElse("");
     ReceiptEntity receiptEntity =
         this.getReceiptEntity(
-            request.getIdPA(),
+            request.getReceipt().getFiscalCode(),
             request.getReceipt().getCreditorReferenceId(),
             debtorIdentifier,
             request.getReceipt().getPaymentDateTime().toString());
@@ -935,7 +935,7 @@ public class PartnerService {
 
     return this.getReceiptExceptionHandling(
         request.getReceipt().getNoticeNumber(),
-        request.getIdPA(),
+        request.getReceipt().getFiscalCode(),
         request.getReceipt().getCreditorReferenceId(),
         isStandIn,
         body,
@@ -944,14 +944,14 @@ public class PartnerService {
 
   private PaymentOptionModelResponse getReceiptExceptionHandling(
       String noticeNumber,
-      String idPa,
+      String organizationFiscalCode,
       String creditorReferenceId,
       boolean isStandIn,
       PaymentOptionModel body,
       ReceiptEntity receiptEntity) {
     try {
       return this.getReceiptPaymentOption(
-          noticeNumber, idPa, creditorReferenceId, isStandIn, body, receiptEntity);
+          noticeNumber, organizationFiscalCode, creditorReferenceId, isStandIn, body, receiptEntity);
     } catch (RetryableException e) {
       log.error(
           "[getReceiptPaymentOption] PAA_SYSTEM_ERROR: GPD Not Reachable [noticeNumber={}]",
@@ -1003,8 +1003,8 @@ public class PartnerService {
   }
 
   private ReceiptEntity getReceiptEntity(
-      String idPa, String creditorReferenceId, String debtor, String paymentDateTime) {
-    ReceiptEntity receiptEntity = new ReceiptEntity(idPa, creditorReferenceId);
+      String organizationFiscalCode, String creditorReferenceId, String debtor, String paymentDateTime) {
+    ReceiptEntity receiptEntity = new ReceiptEntity(organizationFiscalCode, creditorReferenceId);
     receiptEntity.setDebtor(debtor);
     String paymentDateTimeIdentifier = Optional.ofNullable(paymentDateTime).orElse("");
     receiptEntity.setPaymentDateTime(paymentDateTimeIdentifier);
@@ -1013,7 +1013,7 @@ public class PartnerService {
 
   private PaymentOptionModelResponse getReceiptPaymentOption(
       String noticeNumber,
-      String idPa,
+      String organizationFiscalCode,
       String creditorReferenceId,
       boolean isStandIn,
       PaymentOptionModel body,
@@ -1021,7 +1021,7 @@ public class PartnerService {
       throws FeignException, URISyntaxException, InvalidKeyException, StorageException {
     PaymentOptionModelResponse paymentOption = new PaymentOptionModelResponse();
     try {
-      paymentOption = gpdClient.sendPaymentOptionReceipt(idPa, noticeNumber, body);
+      paymentOption = gpdClient.sendPaymentOptionReceipt(organizationFiscalCode, noticeNumber, body);
 
       // To exclude receipts from being saved, it is necessary to know if a PD is not ACA.
       boolean isNotACA = true; // default GPD -> it isn't ACA
@@ -1041,7 +1041,7 @@ public class PartnerService {
             "[getReceiptPaymentOption] PAA_RECEIPT_DUPLICATA: GPD Conflict Error Response [noticeNumber={}]",
             noticeNumber,
             e);
-        boolean receiptNotFoundInStorage = this.getReceipt(idPa, creditorReferenceId) == null;
+        boolean receiptNotFoundInStorage = this.getReceipt(organizationFiscalCode, creditorReferenceId) == null;
 
         boolean isNotACA = true; // default GPD -> it isn't ACA
         if(paymentOption.getServiceType() != null) {

--- a/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PartnerService.java
@@ -1075,13 +1075,13 @@ public class PartnerService {
 
   public PaymentOptionModelResponse getReceiptPaymentOptionScheduler(
       String noticeNumber,
-      String idPa,
+      String receiptFiscalCode,
       String creditorReferenceId,
       boolean isStandIn,
       PaymentOptionModel body,
       ReceiptEntity receiptEntity)
       throws FeignException, URISyntaxException, InvalidKeyException, StorageException {
-    return getReceiptPaymentOption(noticeNumber, idPa, creditorReferenceId, isStandIn, body, receiptEntity);
+    return getReceiptPaymentOption(noticeNumber, receiptFiscalCode, creditorReferenceId, isStandIn, body, receiptEntity);
   }
 
   private PaymentsModelResponse getAndValidatePaymentOption(

--- a/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.NotBlank;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 
@@ -259,7 +260,7 @@ public class PaymentsService {
     }
     
     private String[] normalizeDateRange(String from, String to) {
-        LocalDateTime today = LocalDateTime.now();
+        LocalDateTime today = LocalDateTime.now(ZoneId.systemDefault());
 
         String normalizedFromInput = normalizeDateInput(from);
         String normalizedToInput = normalizeDateInput(to);

--- a/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/PaymentsService.java
@@ -326,4 +326,6 @@ public class PaymentsService {
             to.toString()
         };
     }
+
+
 }

--- a/src/main/java/it/gov/pagopa/payments/service/SchedulerService.java
+++ b/src/main/java/it/gov/pagopa/payments/service/SchedulerService.java
@@ -93,7 +93,7 @@ public class SchedulerService {
 
         Element node = (Element) nodes.item(0);
 
-        String idPA = node.getElementsByTagName("idPA").item(0).getTextContent();
+        String receiptFiscalCode = node.getElementsByTagName("fiscalCode").item(0).getTextContent();
         String creditorReferenceId = node.getElementsByTagName("creditorReferenceId").item(0).getTextContent();
         String noticeNumber = node.getElementsByTagName("noticeNumber").item(0).getTextContent();
         String paymentDateTime = node.getElementsByTagName("paymentDateTime").item(0).getTextContent();
@@ -109,7 +109,7 @@ public class SchedulerService {
             standInString = standInNodeList.item(0).getTextContent();
         }
 
-        ReceiptEntity receiptEntity = new ReceiptEntity(idPA, creditorReferenceId);
+        ReceiptEntity receiptEntity = new ReceiptEntity(receiptFiscalCode, creditorReferenceId);
         receiptEntity.setDebtor(entityUniqueIdentifierValue);
         String paymentDateTimeIdentifier = Optional.ofNullable(paymentDateTime).orElse("");
         receiptEntity.setPaymentDateTime(paymentDateTimeIdentifier);
@@ -128,14 +128,14 @@ public class SchedulerService {
         try {
             partnerService.getReceiptPaymentOptionScheduler(
                     noticeNumber,
-                    idPA,
+                    receiptFiscalCode,
                     creditorReferenceId,
                     Boolean.parseBoolean(standInString),
                     body,
                     receiptEntity);
             queueClient.deleteMessage(queueMessageItem.getMessageId(), queueMessageItem.getPopReceipt());
         } catch (FeignException | URISyntaxException | InvalidKeyException | StorageException e) {
-            log.debug("[paSendRT] Retry failed [fiscalCode={},noticeNumber={}]\",\n", idPA, noticeNumber);
+            log.debug("[paSendRT] Retry failed [fiscalCode={},noticeNumber={}]\",\n", receiptFiscalCode, noticeNumber);
             queueClient.updateMessageWithResponse(
                     queueMessageItem.getMessageId(),
                     queueMessageItem.getPopReceipt(),
@@ -145,7 +145,7 @@ public class SchedulerService {
                     Context.NONE);
         } catch (PartnerValidationException e) {
             // { PAA_RECEIPT_DUPLICATA, PAA_PAGAMENTO_SCONOSCIUTO }
-            log.warn("[paSendRT] Retry failed {} [fiscalCode={},noticeNumber={}]\",\n", e.getMessage(), idPA, noticeNumber);
+            log.warn("[paSendRT] Retry failed {} [fiscalCode={},noticeNumber={}]\",\n", e.getMessage(), receiptFiscalCode, noticeNumber);
             queueClient.deleteMessage(queueMessageItem.getMessageId(), queueMessageItem.getPopReceipt());
         }
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Use `paSendRt.receipt.fiscalCode` instead of `paSendRT.idPA` field to retrieve the fiscal code of the debt position to be updated
<!--- Describe your changes in detail -->

#### Motivation and Context
there are cases where paSendRT is sent in broadcast to multiple EC's.
It has happened that a multibeneficiary payment has triggered paSendRt to both the creditor institutions, the primary and the secondary ones.
In this case both the creditor institutions had a same payment position with the same IUV.
Since logic was using idPA field instead of the receipt.fiscalCode field it have caused the wrong debt position to be updated as paid
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.